### PR TITLE
Fix mistake in docs for sample config

### DIFF
--- a/CUSTOMIZING.org
+++ b/CUSTOMIZING.org
@@ -333,7 +333,6 @@ same remote host, see: https://github.com/stsquad/dired-rsync/issues/24.
   ;; In case you want the details at startup like `dired'
   ;; (dirvish-hide-details nil)
   :config
-  ;; Place this line under :init to ensure the overriding at startup, see #22
   (dirvish-peek-mode)
   ;; Dired options are respected except a few exceptions,
   ;; see *In relation to Dired* section above


### PR DESCRIPTION
For new users using use-package dirvish wont get loaded when (dirvish-override-dired-mode) is in :config. Instead use :init