### PR TITLE
fix: embark-export-dired fails when used in combination with e.g consult-fd

### DIFF
--- a/dirvish.el
+++ b/dirvish.el
@@ -1480,7 +1480,17 @@ With optional NOSELECT just find files but do not select them."
          (flags (or flags (dv-ls-switches dv)))
          (mc dirvish-large-directory-threshold)
          (buffer (alist-get key (dv-roots dv) nil nil #'equal))
-         (new? (null buffer)) (dps (dv-preview-dispatchers dv))
+         ;; embark-export-dired uses a hack to force dired to create a new
+         ;; buffer documented here:
+         ;; https://github.com/oantolin/embark/issues/675
+         ;; make dirvish aware of it so it also creates new buffer. Without this
+         ;; code when opening a directory in dirvish and then using e.g
+         ;; consult-fd combined with embark-export in that folder it fails
+         ;; because it tries to reuse the existing buffer
+         (new? (or
+                (null buffer)
+                (eq (symbol-function 'dired-find-buffer-nocreate) #'ignore)))
+         (dps (dv-preview-dispatchers dv))
          (hist (cons key nil)) tramp fd)
     (setf (dv-timestamp dv) (dirvish--timestamp))
     (cond ((and new? remote)


### PR DESCRIPTION
Hi

Sorry for writing a crap description. Just don't want to spend a lot of time on this if it never goes anywhere.
Let me know if you see this and want it merged and I'll fix it up with proper steps to reproduce etc

Summary of the problem and fix:
         ;; embark-export-dired uses a hack to force dired to create a new
         ;; buffer documented here:
         ;; https://github.com/oantolin/embark/issues/675
         ;; make dirvish aware of it so it also creates new buffer. Without this
         ;; code when opening a directory in dirvish and then using e.g
         ;; consult-fd combined with embark-export in that folder it fails
         ;; because it tries to reuse the existing buffer
